### PR TITLE
Current_entity method, ReadMe changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ class AuthenticationController < ApplicationController
 end
 ```
 > Note that our controller extends from ApplicationController.
+> It could also extend from your custom ApiController, for example.
 
-### <a name='custom-validations'> Entity tracking and custom validations
+### Entity tracking
 
-#### Validations before giving out a token? Override `authenticate_entity`:
+#### Override `authenticate_entity`. Add validations for your entity:
 
 ```ruby
-# application_controller.rb
+# authentication_controller.rb
 def authenticate_entity(params)
   entity = Entity.find_by(some_unique_id: params[:some_unique_id])
   return nil unless entity.present? && entity.valid_password?(params[:password])
@@ -78,7 +79,7 @@ end
 ```
 > Returning no value or false won't create the authentication token.
 
-#### Keeping track of entities? Override: `entity_payload`:
+#### Override `entity_payload`, `find_authenticable_entity` to have access to `current_entity`:
 
 ```ruby
 # application_controller.rb
@@ -92,6 +93,11 @@ def find_authenticable_entity(entity_payload_returned_object)
   Entity.find_by(id: entity_payload_returned_object.fetch(ENTITY_KEY))
 end
 ```
+
+Overriding these methods will give you access to `current_entity` from any controller that extends `application_controller`.
+It will return the entity you used to authenticate.
+
+### Custom Validations
 
 #### Validations in every request? Override `entity_custom_validation_value` to get it verified as the following:
 

--- a/lib/wor/authentication/controller.rb
+++ b/lib/wor/authentication/controller.rb
@@ -23,7 +23,7 @@ module Wor
       end
 
       def current_entity
-        find_authenticable_entity(decoded_token)
+        @current_entity ||= find_authenticable_entity(decoded_token)
       end
 
       ##

--- a/lib/wor/authentication/controller.rb
+++ b/lib/wor/authentication/controller.rb
@@ -22,8 +22,12 @@ module Wor
         Wor::Authentication.maximum_useful_days.days.from_now.to_i
       end
 
+      def current_entity
+        find_authenticable_entity(decoded_token)
+      end
+
       ##
-      # Helpers which may be overrided
+      # Helpers which may be overridden
       ##
 
       def token_renew_id

--- a/lib/wor/authentication/token_manager.rb
+++ b/lib/wor/authentication/token_manager.rb
@@ -3,16 +3,18 @@ require 'jwt'
 module Wor
   module Authentication
     class TokenManager
+      ENCODING_ALGORITHM = 'HS256'.freeze
+
       def initialize(key)
         @key = key
       end
 
       def encode(payload)
-        JWT.encode(payload, @key)
+        JWT.encode(payload, @key, ENCODING_ALGORITHM)
       end
 
       def decode(token)
-        payload = JWT.decode(token, @key)[0]
+        payload = JWT.decode(token, @key, true, algorithm: ENCODING_ALGORITHM)[0]
         Wor::Authentication::DecodedToken.new(payload)
       rescue
         raise Wor::Authentication::Exceptions::InvalidAuthorizationToken

--- a/spec/wor/authentication/controller_spec.rb
+++ b/spec/wor/authentication/controller_spec.rb
@@ -34,8 +34,12 @@ describe ApplicationController, type: :controller do
         subject.request = request
       end
 
-      it 'raises InvalidAuthorizationToken' do
+      it 'does not raise an error' do
         expect { subject.authenticate_request }.not_to raise_error
+      end
+
+      it 'has access to the current entity method' do
+        expect(subject.current_entity).to be {}
       end
     end
   end

--- a/wor-authentication.gemspec
+++ b/wor-authentication.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'railties', '>= 4.1.0', '< 5.2'
   spec.add_dependency 'devise', '>= 4.2.0'
-  spec.add_dependency 'jwt', '>= 1.5'
+  spec.add_dependency 'jwt', '~> 2.0'
   spec.add_dependency 'rails', '>= 4.0'
 
   spec.add_development_dependency 'byebug', '~> 9.0'


### PR DESCRIPTION
## Summary

- Added `current_entity` method to the gem so users don't have to write it every time.
- Changed some Readme details, added the `current_entity` info and how to use it.